### PR TITLE
Added ServerActive configuration option for Zabbix agents

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,7 @@ default['zabbix']['agent']['install'] = true
 default['zabbix']['agent']['version'] = "2.0.0"
 default['zabbix']['agent']['branch'] = "ZABBIX%20Latest%20Stable"
 default['zabbix']['agent']['servers'] = []
+default['zabbix']['agent']['servers_active'] = []
 default['zabbix']['agent']['hostname'] = node.fqdn
 default['zabbix']['agent']['configure_options'] = [ "--with-libcurl" ]
 default['zabbix']['agent']['install_method'] = "prebuild"

--- a/templates/default/zabbix_agentd.conf.erb
+++ b/templates/default/zabbix_agentd.conf.erb
@@ -6,4 +6,7 @@ LogRemoteCommands=1
 Include=<%= node.zabbix.agent.include_dir %>
 PidFile=<%= node.zabbix.run_dir %>/zabbix_agentd.pid
 Server=<%= node.zabbix.agent.servers.join(',') %>
+<% if node.zabbix.agent.servers_active.first -%>
+ServerActive=<%= node.zabbix.agent.servers_active.join(',') %>
+<% end -%>
 StartAgents=4


### PR DESCRIPTION
ServerActive allows for active auto client registration with the Zabbix server. To enable set servers_active attribute.
