### PR TITLE
added restart option to zabbix_agentd service definitions

### DIFF
--- a/recipes/agent_prebuild.rb
+++ b/recipes/agent_prebuild.rb
@@ -17,7 +17,7 @@ end
 
 # Define zabbix_agentd service
 service "zabbix_agentd" do
-  supports :status => true, :start => true, :stop => true
+  supports :status => true, :start => true, :stop => true, :restart => true
   action [ :enable ]
 end
 

--- a/recipes/agent_source.rb
+++ b/recipes/agent_source.rb
@@ -45,7 +45,7 @@ end
 
 # Define zabbix_agentd service
 service "zabbix_agentd" do
-  supports :status => true, :start => true, :stop => true
+  supports :status => true, :start => true, :stop => true, :restart => true
   action [ :enable ]
 end
 


### PR DESCRIPTION
Zabbix agent was not restarting post installation. Quick fix adding

 :restart => true

to agent prebuild and source scripts.
