### PR TITLE
Add missing shabang for init file.

### DIFF
--- a/templates/default/zabbix_agentd.init.erb
+++ b/templates/default/zabbix_agentd.init.erb
@@ -1,5 +1,5 @@
 #!/bin/sh
-#### BEGIN INIT INFO
+### BEGIN INIT INFO
 # Provides:          zabbix_agentd
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
I got the following error on ubuntu:

```
service[zabbix_agentd] (zabbix::agent_prebuild line 24) had an error: Errno::ENOEXEC: Exec format error - /etc/init.d/zabbix_agentd status
```

This fixed the issue (thanks to http://brianoneill.blogspot.com/2009/07/exec-format-error-in-cron.html ). :)
