### PR TITLE
Add support for custom config file location to zabbix_agentd.init-rh.erb

### DIFF
--- a/templates/default/zabbix_agentd.init-rh.erb
+++ b/templates/default/zabbix_agentd.init-rh.erb
@@ -41,7 +41,7 @@ chown -R zabbix:zabbix "$DIR"
 
 start()
 {
-  start_daemon -p $PID $DAEMON
+  start_daemon -p $PID $DAEMON -c <%= node.zabbix.etc_dir %>/zabbix_agentd.conf
   RETVAL=$?
   [ $RETVAL -eq 0 ] && touch $LOCK
   return $RETVAL


### PR DESCRIPTION
zabbix_agentd.init-rh.erb wouldn't start the zabbix_agentd without setting the /etc location to /usr/local/etc. Added support to the init script for the node['zabbix']['etc_dir'] attribute.
