### PR TITLE
Duplicate configure options, otherwise immutable error

### DIFF
--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -49,7 +49,8 @@ packages.each do |pck|
   end
 end
 
-configure_options = (node['zabbix']['server']['configure_options'] || Array.new).delete_if do |option|
+configure_options = node['zabbix']['server']['configure_options'].dup
+configure_options = (configure_options || Array.new).delete_if do |option|
   option.match(/\s*--prefix(\s|=).+/)
 end
 case node['zabbix']['database']['install_method']


### PR DESCRIPTION
Array needs to be duplicated, otherwise you get an error about changing an immutable property

Not sure if this is the prefered way to solve it though
