### PR TITLE
Node options are immutable, so we need to make a copy before removing an...

### DIFF
--- a/recipes/agent_source.rb
+++ b/recipes/agent_source.rb
@@ -29,9 +29,18 @@ when "redhat","centos","scientific","amazon"
 end
 
 # --prefix is controlled by install_dir
-configure_options = (node['zabbix']['agent']['configure_options'] || Array.new).delete_if do |option|
-  option.match(/\s*--prefix(\s|=).+/)
+node_options = node['zabbix']['agent']['configure_options']
+configure_options = Array.new
+
+if node_options
+  node.set['zabbix']['agent']['configure_options'].delete_if do |option|
+    option.match(/\s*--prefix(\s|=).+/)
+  end
+  node_options.each do |item|
+    configure_options << item
+  end
 end
+
 node.set['zabbix']['agent']['configure_options'] = configure_options
 
 zabbix_source "install_zabbix_agent" do


### PR DESCRIPTION
...y --prefix options

See this pull request for similar fix on the server:
https://github.com/laradji/zabbix/pull/48
https://github.com/AdallomRoy/zabbix/commit/0ecab38ce4545c479cb52f65b1a1b570baba7857
