### PR TITLE
missing value in server_source

### DIFF
--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -50,7 +50,7 @@ packages.each do |pck|
 end
 
 configure_options = node['zabbix']['server']['configure_options'].dup
-configure_options = (|| Array.new).delete_if do |option|
+configure_options = (configure_options || Array.new).delete_if do |option|
   option.match(/\s*--prefix(\s|=).+/)
 end
 case node['zabbix']['database']['install_method']


### PR DESCRIPTION
Resolve this:

```
FATAL: Cookbook file recipes/server_source.rb has a ruby syntax error:
FATAL: /root/chef-repo/cookbooks/zabbix/recipes/server_source.rb:53: syntax error, unexpected tOROP
FATAL: configure_options = (|| Array.new).delete_if do |option|
FATAL:                        ^
```
