### PR TITLE
Expand Graph LWRP to handle almost all possible values

### DIFF
--- a/libraries/chef_zabbix_api.rb
+++ b/libraries/chef_zabbix_api.rb
@@ -197,6 +197,24 @@ class Chef
         enum :aggregated, 1
         enum :graph,      2
       end
+
+      class GraphType
+        include Enumeration
+        enum :normal, 0
+        enum :stacked, 1
+        enum :pie, 2
+        enum :exploded, 3
+      end
+
+      class GraphAxisType
+        include Enumeration
+        enum :calculated, 0
+        enum :fixed, 1
+        # TODO: Update the graph provider to do an update after it has created
+        # all of its item so that you can map an item id and support this value
+        #enum :item, 2
+      end
     end
+
   end
 end

--- a/providers/graph.rb
+++ b/providers/graph.rb
@@ -19,9 +19,25 @@ action :create do
 
     params = {
       :name => new_resource.name,
-      :show_triggers => new_resource.show_triggers ? '1' : '0',
+
       :width => new_resource.width,
       :height => new_resource.height,
+      :yaxismin => new_resource.yaxismin,
+      :yaxismax => new_resource.yaxismax,
+      :percent_left => new_resource.percent_left,
+      :percent_right => new_resource.percent_right,
+
+      :show_work_period => new_resource.show_work_period ? '1' : '0',
+      :show_triggers => new_resource.show_triggers ? '1' : '0',
+      :show_legend => new_resource.show_legend ? '1' : '0',
+      :show_3d => new_resource.show_3d ? '1' : '0',
+
+      :type => new_resource.type.value,
+      :ymin_type => new_resource.ymin_type.value,
+      :ymax_type => new_resource.ymax_type.value,
+      :ymin_item => new_resource.ymin_item.to_s,
+      :ymax_item => new_resource.ymax_item.to_s,
+
       :gitems => new_resource.graph_items.map(&:to_hash)
     }
     method = 'graph.create'

--- a/resources/graph.rb
+++ b/resources/graph.rb
@@ -2,10 +2,27 @@ actions :create
 default_action :create
 
 attribute :name, :kind_of => String, :required => true
-attribute :template, :kind_of => String, :required => true
-attribute :show_triggers, :kind_of => [TrueClass, FalseClass], :default => false
-attribute :width, :kind_of => Fixnum, :required => true
-attribute :height, :kind_of => Fixnum, :required => true
+
+attribute :width, :kind_of => Fixnum, :default => 900
+attribute :height, :kind_of => Fixnum, :default  => 200
+attribute :yaxismin, :kind_of => Float, :default => 0.000
+attribute :yaxismax, :kind_of => Float, :default => 100.000
+attribute :percent_left, :kind_of => Float, :default => 0.000
+attribute :percent_right, :kind_of => Float, :default => 0.000
+
+attribute :show_work_period, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :show_triggers, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :show_legend, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :show_3d, :kind_of => [TrueClass, FalseClass], :default => false
+
+attribute :type, :kind_of => Zabbix::API::GraphType, :default => Zabbix::API::GraphType.normal
+attribute :ymin_type, :kind_of => Zabbix::API::GraphAxisType, :default => Zabbix::API::GraphAxisType.calculated
+attribute :ymax_type, :kind_of => Zabbix::API::GraphAxisType, :default => Zabbix::API::GraphAxisType.calculated
+# TODO: eventually these will be strings that could be floats for GraphAxisType.fixed 
+# or could reference an item_id for GraphAxisType.item
+attribute :ymin_item, :kind_of => Float, :default => 0.000
+attribute :ymax_item, :kind_of => Float, :default => 0.000
+
 attribute :graph_items, :kind_of => Array, :required => true
 
 attribute :server_connection, :kind_of => Hash, :required => true


### PR DESCRIPTION
Currently Excludes having an axis type of 'item' because that requires
saving the graph and then editing it immediately which is a fairly large
change
