### PR TITLE
Remove mysql-devel package

### DIFF
--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -32,7 +32,6 @@ when "redhat","centos","scientific","amazon","oracle"
     php_packages = (node['platform_version'].to_i < 6)?
       %w{ php53-mysql php53-gd php53-bcmath php53-mbstring php53-xml } :
       %w{ php-mysql php-gd php-bcmath php-mbstring php-xml }
-    packages.push('mysql-devel')
     packages.push(*php_packages)
   when 'postgres'
     php_packages = (node['platform_version'].to_i < 6)?


### PR DESCRIPTION
because it conflicts with some versions of msql (percona) and isn't required to build the server
