### PR TITLE
fixed order of operations bug

### DIFF
--- a/recipes/_agent_common_user.rb
+++ b/recipes/_agent_common_user.rb
@@ -11,7 +11,7 @@ if node['zabbix']['agent']['user']
     home node['zabbix']['install_dir']
     shell node['zabbix']['agent']['shell']
     uid node['zabbix']['agent']['uid'] if node['zabbix']['agent']['uid']
-    gid node['zabbix']['agent']['gid'] or node['zabbix']['agent']['group']
+    gid node['zabbix']['agent']['gid'] || node['zabbix']['agent']['group']
     system true
     supports :manage_home=>true
   end


### PR DESCRIPTION
this code evaluated like
gid(node['zabbix']['agent']['gid']) or node['zabbix']['agent']['group']

instead of the expected

gid(node['zabbix']['agent']['gid'] or node['zabbix']['agent']['group'])

the || operator should fixes this because it's got higher precedence.
