### PR TITLE
Permit usage of syslog for zabbix_server

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -1,9 +1,12 @@
+include_attribute "zabbix"
+
 default['zabbix']['server']['version']                = "2.0.3"
 default['zabbix']['server']['branch']                 = "ZABBIX%20Latest%20Stable"
 default['zabbix']['server']['source_url']             = nil
 default['zabbix']['server']['install_method']         = "source"
 default['zabbix']['server']['configure_options']      = [ "--with-libcurl","--with-net-snmp"]
 default['zabbix']['server']['include_dir']            = "/opt/zabbix/server_include"
+default['zabbix']['server']['log_file']               = ::File.join(node['zabbix']['log_dir'], "zabbix_server.log")
 default['zabbix']['server']['log_level']              = 3
 default['zabbix']['server']['housekeeping_frequency'] = "1"
 default['zabbix']['server']['max_housekeeper_delete'] = "100000"

--- a/templates/default/zabbix_server.conf.erb
+++ b/templates/default/zabbix_server.conf.erb
@@ -2,7 +2,9 @@
 
 ############ GENERAL PARAMETERS #################
 
-LogFile=<%= node['zabbix']['log_dir'] %>/zabbix_server.log
+<% if node['zabbix']['server']['log_file'] -%>
+LogFile=<%= node['zabbix']['server']['log_file'] %>
+<% end -%>
 
 DBHost=<%= @dbhost %>
 DBName=<%= @dbname %>


### PR DESCRIPTION
Don't change behaviour for anyone, default to Logfile
But set "nil" or "false" to node["zabbix"]["server"]["log_file"] disable it and use syslog instead
