### PR TITLE
We must add common recipe at first

### DIFF
--- a/recipes/agent_common.rb
+++ b/recipes/agent_common.rb
@@ -1,3 +1,4 @@
+include_recipe "zabbix::common"
 include_recipe "zabbix::_agent_common_user"
 include_recipe "zabbix::_agent_common_directories"
 include_recipe "zabbix::_agent_common_service"


### PR DESCRIPTION
This fix "/etc/zabbix" doesn't exist when deploy an agent from scratch
