### PR TITLE
fix error on windows when creating root_dirs

### DIFF
--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -13,12 +13,23 @@ root_dirs = [
 ]
 
 # Create root folders
-root_dirs.each do |dir|
-  directory dir do
-    owner "root"
-    group "root"
-    mode "755"
-    recursive true
+case node['platform_family']
+when "windows"
+  root_dirs.each do |dir|
+    directory dir do
+      owner "Administrator"
+      rights :read, "Everyone", option  => :applies_to_children
+      recursive true
+    end
+  end
+else
+  root_dirs.each do |dir|
+    directory dir do
+      owner "root"
+      group "root"
+      mode "755"
+      recursive true
+    end
   end
 end
 


### PR DESCRIPTION
fix error on windows when creating root_dirs. On windows, user should be
Administrator.
