### PR TITLE
be sure that user is created before directory

### DIFF
--- a/recipes/agent_common.rb
+++ b/recipes/agent_common.rb
@@ -1,4 +1,4 @@
-include_recipe "zabbix::common"
 include_recipe "zabbix::_agent_common_user"
+include_recipe "zabbix::common"
 include_recipe "zabbix::_agent_common_directories"
 include_recipe "zabbix::_agent_common_service"

--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -7,8 +7,8 @@
 # Apache 2.0
 #
 
-include_recipe "zabbix::common"
 include_recipe "zabbix::server_common"
+include_recipe "zabbix::common"
 
 packages = Array.new
 case node['platform']


### PR DESCRIPTION
zabbix_common create /var/log/zabbix and try to set owner to user that is created in _agent_common_user or server_common. Be sure that this creation is performed before the directory creation to avoid problem in zabbix_server start
