### PR TITLE
Add agent listen port as a config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ example :
 	  node.set['zabbix']['agent']['source_url'] = nil
 	  node.set['zabbix']['agent']['install_method'] = "prebuild"
 
+Additionally, you can set the listener port explicitly with the following (it otherwise will set to the zabbix default value):
+
+	node.set['zabbix']['agent']['listener_port'] = "11011"
+
 ## Database
 
     node.set['zabbix']['database']['install_method'] = 'mysql'

--- a/templates/default/zabbix_agentd.conf.erb
+++ b/templates/default/zabbix_agentd.conf.erb
@@ -22,3 +22,6 @@ ServerActive=<%= node.zabbix.agent.servers_active.join(',') %>
 <% if node['zabbix']['agent']['start_agents'] -%>
 StartAgents=<%= node['zabbix']['agent']['start_agents'] %>
 <% end -%>
+<% if node['zabbix']['agent']['listen_port'] -%>
+ListenPort=<%=node['zabbix']['agent']['listen_port'] -%>
+<% end -%>


### PR DESCRIPTION
Add ability to set the listen port for zabbix agents. This will essentially override the zabbix default. If this attribute is not passed into the chef run, then the agent will use the default port set by zabbix (currently 10050). If a value is passed in, then the port is explicitly set in the conf file.

Also added doc to this effect.
