### PR TITLE
Use vagrant-omnibus to install the latest Chef omnibus version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# This Vagrantfile needs the vagrant-omnbius plugin installed
+# To install this, run "vagrant plugin install vagrant-omnibus"
+
 Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |vbox|
     vbox.customize ['modifyvm', :id,


### PR DESCRIPTION
This method is a fair bit cleaner, and also compatible with all base boxes. 
I took the latest, but it can be forced to a version if necessary.

This requires the plugin vagrant-omnibus, to install run

```
$ vagrant plugin install vagrant-omnibus
```
