### PR TITLE
Allow specific interface to be used for agent polling.

### DIFF
--- a/recipes/agent_registration.rb
+++ b/recipes/agent_registration.rb
@@ -36,28 +36,28 @@ end
 
 interface_definitions = {
   :zabbix_agent => {
-     :type => 1,
-     :main => 1,
-     :useip => 1,
-     :ip => ip_address,
-     :dns => node['fqdn'],
-     :port => "10050"
+    :type => 1,
+    :main => 1,
+    :useip => 1,
+    :ip => ip_address,
+    :dns => node['fqdn'],
+    :port => '10050'
   },
   :jmx => {
-     :type => 4,
-     :main => 1,
-     :useip => 1,
-     :ip => ip_address,
-     :dns => node['fqdn'],
-     :port => "10052"
+    :type => 4,
+    :main => 1,
+    :useip => 1,
+    :ip => ip_address,
+    :dns => node['fqdn'],
+    :port => '10052'
   },
   :snmp => {
-     :type => 2,
-     :main => 1,
-     :useip => 1,
-     :ip => ip_address,
-     :dns => node['fqdn'],
-     :port => "161"
+    :type => 2,
+    :main => 1,
+    :useip => 1,
+    :ip => ip_address,
+    :dns => node['fqdn'],
+    :port => '161'
   }
 }
 


### PR DESCRIPTION
Hello,

We have a couple of different environments which have different interfaces such as eth0 for management and eth1 for customer traffic. What I needed was a way to tell the agent registration recipe which interface to register the node with so that the Zabbix server will poll the correct IP (i.e., the management IP).  Another use case for this is when testing on vagrant - eth0 is (often) the NAT interface and you may have another host-only interface on eth1. The zabbix server needs to use the host-only interface on eth1 since it can't reach the IP on eth0 (the NAT'ed interface).

This PR is an attempt to do that and it seems to work with my testing. The intention is that the user of the cookbook knows best how to determine which interface to use and would set the node['zabbix']['agent']['network_interface'] in a wrapper cookbook.

Feedback welcome.
