### PR TITLE
RHEL 5 does not support "manage home" usermod option.

### DIFF
--- a/recipes/_agent_common_user.rb
+++ b/recipes/_agent_common_user.rb
@@ -1,3 +1,13 @@
+# RHEL 5 and below does not seem to support 
+# managed home directories. 
+manage_home = true # most distros do support managed home so leave at true
+if (node['platform_family'] == "rhel")
+  rhel_major = (node['platform_version'].match /^([0-9]+)\.[0-9]+/)[1].to_i
+  if rhel_major <= 5
+    manage_home = false
+  end
+end
+
 # Manage user and group
 if node['zabbix']['agent']['user']
   # Create zabbix group
@@ -13,6 +23,6 @@ if node['zabbix']['agent']['user']
     uid node['zabbix']['agent']['uid'] if node['zabbix']['agent']['uid']
     gid node['zabbix']['agent']['gid'] || node['zabbix']['agent']['group']
     system true
-    supports :manage_home=>true
+    supports :manage_home=>manage_home
   end
 end


### PR DESCRIPTION
In my testing it seems that Red Hat 5 and below does not support the "manage home" usermod option - when Chef runs with that option enabled the run fails due to usermod complaining. This is despite the help text in usermod implying that you can run "-d" and "-m" together; I have not been able to get it to work on older RHEL machines.

This PR detects RHEL 5 and disables that option. It should not have an adverse impact on the agent and in my testing it still seems to work fine. If more distros do not support this option then the code may have to be refactored into a case statement.
