### PR TITLE
Update Berksfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,3 @@
-site :opscode
-# source "http://api.berkshelf.com"
+source "http://api.berkshelf.com"
 
 metadata


### PR DESCRIPTION
Site locations have been deprecated as of Berkshelf 3. Updated to reflect use of Berkshelf API server.
