### PR TITLE
Use strip_components in agent_prebuild.rb

### DIFF
--- a/recipes/agent_prebuild.rb
+++ b/recipes/agent_prebuild.rb
@@ -19,7 +19,7 @@ ark 'zabbix_agent' do
   group node['zabbix']['agent']['group']
   action :put
   path  '/opt'
-  strip_leading_dir false
+  strip_components 0
   has_binaries ['bin/zabbix_sender', 'bin/zabbix_get', 'sbin/zabbix_agent', 'sbin/zabbix_agentd']
   notifies :restart, 'service[zabbix_agentd]'
   checksum node['zabbix']['agent']['checksum']


### PR DESCRIPTION
The strip_leading_dir attribute was deprecated in favor of strip_components. The agent_prebuild recipe was failing using strip_leading_dir false. The tarball was extracting directly to /opt rather than /opt/zabbix resulting in failure to find /opt/zabbix/sbin/zabbix_agentd when starting the service.
