### PR TITLE
Move IP to attributes to allow override elsewhere

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -15,6 +15,7 @@ default['zabbix']['agent']['include_dir']       = ::File.join(node['zabbix']['et
 default['zabbix']['agent']['enable_remote_commands'] = true
 default['zabbix']['agent']['listen_port']       = '10050'
 default['zabbix']['agent']['timeout']       	= '3'
+default['zabbix']['agent']['ipaddress']         = node['ipaddress']
 
 default['zabbix']['agent']['config_file']               = ::File.join(node['zabbix']['etc_dir'], 'zabbix_agentd.conf')
 default['zabbix']['agent']['userparams_config_file']    = ::File.join(node['zabbix']['agent']['include_dir'], 'user_params.conf')

--- a/recipes/agent_registration.rb
+++ b/recipes/agent_registration.rb
@@ -28,7 +28,7 @@ interface_definitions = {
     :type => 1,
     :main => 1,
     :useip => 1,
-    :ip => node['ipaddress'],
+    :ip => node['zabbix']['agent']['ipaddress'] ,
     :dns => node['fqdn'],
     :port => '10050'
   },
@@ -36,7 +36,7 @@ interface_definitions = {
     :type => 4,
     :main => 1,
     :useip => 1,
-    :ip => node['ipaddress'],
+    :ip => node['zabbix']['agent']['ipaddress'] ,
     :dns => node['fqdn'],
     :port => '10052'
   },
@@ -44,7 +44,7 @@ interface_definitions = {
     :type => 2,
     :main => 1,
     :useip => 1,
-    :ip => node['ipaddress'],
+    :ip => node['zabbix']['agent']['ipaddress'] ,
     :dns => node['fqdn'],
     :port => '161'
   }


### PR DESCRIPTION
This allows the agent's own IP Address to be configurable in a wrapper cookbook or elsewhere.  For example, a user may want to configure zabbix to communicate on a separate network and thus the node's IP would be different.  Much of this configuration could also be done in Ohai with a plugin, however I think this also adds some easily configurable value, especially in use cases such as test kitchen overrides. If this was left out intentionally, I'm all ears for other suggestions!
