### PR TITLE
Fixing host resource and provider out-of-sync

### DIFF
--- a/resources/host.rb
+++ b/resources/host.rb
@@ -19,8 +19,6 @@ attribute :macros, :kind_of => Hash, :default => {}
 # for appropriate inventory hash keys (Property name from the table)
 attribute :inventory, :kind_of => Hash, :default => {}
 
-attribute :interfaces, :kind_of => Array, :default => []
-
 attribute :server_connection, :kind_of => Hash, :default => {}
 attribute :create_missing_groups, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :parameters, :kind_of => Hash, :default => {}


### PR DESCRIPTION
From #173 

> The resources/host.rb file contains attributes for groups, templates and interfaces, but those are currently ignored in the providers/host.rb, since that file is only using the parameters[:groupNames], parameteres[:templates] and parameteres[:interfaces] attribute respectively for registering a host to the Zabbix server.

Fixing this issue while I tried to keep the backward compatibility to not brake the agent_registration recipe and other people's application cookbooks using this resource the old way. Could you please review it?
