### PR TITLE
Don't quote pure numbers

### DIFF
--- a/attributes/database.rb
+++ b/attributes/database.rb
@@ -3,7 +3,7 @@ default['zabbix']['database']['dbname']             = 'zabbix'
 default['zabbix']['database']['dbuser']             = 'zabbix'
 default['zabbix']['database']['dbhost']             = 'localhost'
 default['zabbix']['database']['dbpassword']         = nil
-default['zabbix']['database']['dbport']             = '3306'
+default['zabbix']['database']['dbport']             = 3306
 default['zabbix']['database']['allowed_user_hosts'] = 'localhost'
 
 default['zabbix']['database']['rds_master_user']      = nil

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -8,8 +8,8 @@ default['zabbix']['server']['configure_options']      = ['--with-libcurl', '--wi
 default['zabbix']['server']['include_dir']            = '/opt/zabbix/server_include'
 default['zabbix']['server']['log_file']               = ::File.join(node['zabbix']['log_dir'], 'zabbix_server.log')
 default['zabbix']['server']['log_level']              = 3
-default['zabbix']['server']['housekeeping_frequency'] = '1'
-default['zabbix']['server']['max_housekeeper_delete'] = '100000'
+default['zabbix']['server']['housekeeping_frequency'] = 1
+default['zabbix']['server']['max_housekeeper_delete'] = 100000
 
 default['zabbix']['server']['host'] = 'localhost'
 default['zabbix']['server']['port'] = 10_051
@@ -22,6 +22,6 @@ default['zabbix']['server']['start_pollers'] = 5
 
 default['zabbix']['server']['externalscriptspath'] = '/usr/local/scripts/zabbix/externalscripts/'
 
-default['zabbix']['server']['timeout'] = '3'
+default['zabbix']['server']['timeout'] = 3
 default['zabbix']['server']['value_cache_size'] = '8M' # default 8MB
 default['zabbix']['server']['cache_size'] = '8M' # default 8MB


### PR DESCRIPTION
Don't quote numbers otherwise the [ruby underscore formatting](http://stackoverflow.com/questions/4946305/what-does-the-underscore-mean-in-literal-numbers) (e.g. 100_000) is rendered in templates (should that formatting be added in the future or a wrapper cookbook). 

I got bitten by this in a wrapper cookbook where, because the original attribute is quoted, it was rendered as text with an "_" which made the Zabbix server barf since that is not a valid number.
