### PR TITLE
Added possibility to create custom scripts

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -12,6 +12,7 @@ default['zabbix']['agent']['servers_active']    = []
 default['zabbix']['agent']['hostname']          = node['fqdn']
 default['zabbix']['agent']['configure_options'] = ['--with-libcurl']
 default['zabbix']['agent']['include_dir']       = ::File.join(node['zabbix']['etc_dir'] , 'agent_include')
+default['zabbix']['agent']['scripts_dir']    = ::File.join(node['zabbix']['etc_dir'], 'user_scripts')
 default['zabbix']['agent']['enable_remote_commands'] = true
 default['zabbix']['agent']['listen_port']       = '10050'
 default['zabbix']['agent']['timeout']       	= '3'
@@ -44,3 +45,4 @@ default['zabbix']['agent']['templates']          = []
 default['zabbix']['agent']['interfaces']         = ['zabbix_agent']
 
 default['zabbix']['agent']['user_parameter'] = []
+default['zabbix']['agent']['user_script']    = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'nacer.laradji@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Zabbix Agent/Server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.8.0'
+version '0.8.1'
 supports 'ubuntu', '>= 10.04'
 supports 'debian', '>= 6.0'
 supports 'redhat', '>= 5.0'

--- a/recipes/_agent_common_directories.rb
+++ b/recipes/_agent_common_directories.rb
@@ -1,5 +1,6 @@
 root_dirs = [
-  node['zabbix']['agent']['include_dir']
+  node['zabbix']['agent']['include_dir'],
+  node['zabbix']['agent']['scripts_dir']
 ]
 
 # Create root folders

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -26,6 +26,19 @@ template 'user_params.conf' do
   only_if { node['zabbix']['agent']['user_parameter'].length > 0 }
 end
 
+# Install custom scripts
+node['zabbix']['agent']['user_script'].each do |script|
+  cookbook_file File.join(node['zabbix']['agent']['scripts_dir'], script) do
+    source "scripts/#{script}"
+    unless node['platform_family'] == 'windows'
+      owner 'root'
+      group 'root'
+      mode '755'
+    end
+    action :create_if_missing
+  end
+end
+
 ruby_block 'start service' do
   block do
     true


### PR DESCRIPTION
Such scripts could be used at user parameters later.

This feature is disabled by default. To start using
it you need to do the following:
- enumerate all script you want to be uploaded in
  node['zabbix']['agent']['user_script'] list
- put scripts into files/default/scripts folder.

NOTE: filename should be the same as specified at user_script list

EXAMPLE:
default['zabbix']['agent'] => {
...
'user_script' => ['check_zookeeper.py'],
'user_parameter' => ['zookeeper[*],/etc/zabbix/user_scripts/check_zookeeper.py -s localhost:2181']
}
