### PR TITLE
Load php module for all platforms

### DIFF
--- a/recipes/web_apache.rb
+++ b/recipes/web_apache.rb
@@ -26,7 +26,8 @@ node['zabbix']['web']['packages'].each do |pkg|
   end
 end
 
-package 'libapache2-mod-php5' if platform_family?('debian')
+# install php5 module
+include_recipe 'apache2::mod_php5'
 
 zabbix_source 'extract_zabbix_web' do
   branch node['zabbix']['server']['branch']


### PR DESCRIPTION
Version 2.0.0 of the apache cookbook introduced some breaking changes.  In RHEL distributions the php module isn't loaded causing httpd to fail to start.

The mod_php5 recipe handles loading the module correctly for all platforms. 
