### PR TITLE
add some LSB comment to agent init script

### DIFF
--- a/templates/default/zabbix_agentd.init.erb
+++ b/templates/default/zabbix_agentd.init.erb
@@ -1,12 +1,13 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          zabbix_agentd
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Start zabbix_agentd at boot time
 # Description:       Zabbix agent.
 ### END INIT INFO
-#! /bin/sh
 #
 # Zabbix agent start/stop script.
 #


### PR DESCRIPTION
Remove double /bin/sh and add some LSB comments to avoid warnings below:

```
insserv: Script zabbix_agentd is broken: incomplete LSB comment.
insserv: missing `Required-Start:' entry: please add even if empty.
insserv: missing `Required-Stop:'  entry: please add even if empty.
```
