### PR TITLE
Don't manage zabbix home directory

### DIFF
--- a/recipes/_agent_common_user.rb
+++ b/recipes/_agent_common_user.rb
@@ -13,6 +13,5 @@ if node['zabbix']['agent']['user']
     uid node['zabbix']['agent']['uid'] if node['zabbix']['agent']['uid']
     gid node['zabbix']['agent']['gid'] || node['zabbix']['agent']['group']
     system true
-    supports :manage_home => true
   end
 end


### PR DESCRIPTION
Some distributions set home directories to 0700, breaking the web service.
