### PR TITLE
Updating the gem of ZabbixAPI

### DIFF
--- a/recipes/_providers_common.rb
+++ b/recipes/_providers_common.rb
@@ -1,4 +1,4 @@
 chef_gem 'zabbixapi' do
   action :install
-  version '~> 0.6.3'
+  version '~> 2.4.1'
 end


### PR DESCRIPTION
A couple of months ago I forked this repository in order to make this change and use the providers of that call Zabbix API because the 0.6.3 version of zabbixapi doesnt work anymore with new versions of zabbix.
I already tested and I'm using this in production, so far so good. :)
