### PR TITLE
Fix agent registration

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -47,3 +47,4 @@ default['zabbix']['agent']['zabbix_agent_port']  = '10050'
 default['zabbix']['agent']['snmp_port']          = '161'
 
 default['zabbix']['agent']['user_parameter'] = []
+default['zabbix']['agent']['server_search'] = "recipe:zabbix\\:\\:server"

--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -47,4 +47,4 @@ default['zabbix']['agent']['zabbix_agent_port']  = '10050'
 default['zabbix']['agent']['snmp_port']          = '161'
 
 default['zabbix']['agent']['user_parameter'] = []
-default['zabbix']['agent']['server_search'] = "recipe:zabbix\\:\\:server"
+default['zabbix']['agent']['server_search'] = 'recipe:zabbix\\:\\:server'

--- a/attributes/web.rb
+++ b/attributes/web.rb
@@ -2,6 +2,8 @@ default['zabbix']['web']['login'] = 'admin'
 default['zabbix']['web']['password'] = 'zabbix'
 default['zabbix']['web']['install_method']  = 'apache'
 default['zabbix']['web']['fqdn']            = node['fqdn']
+default['zabbix']['web']['api']['uri'] = "/api_jasonrpc.php"
+default['zabbix']['web']['api']['scheme']   = "http"
 default['zabbix']['web']['aliases']         = ['zabbix']
 default['zabbix']['web']['port']            = 80
 

--- a/attributes/web.rb
+++ b/attributes/web.rb
@@ -2,8 +2,8 @@ default['zabbix']['web']['login'] = 'admin'
 default['zabbix']['web']['password'] = 'zabbix'
 default['zabbix']['web']['install_method']  = 'apache'
 default['zabbix']['web']['fqdn']            = node['fqdn']
-default['zabbix']['web']['api']['uri'] = "/api_jasonrpc.php"
-default['zabbix']['web']['api']['scheme']   = "http"
+default['zabbix']['web']['api']['uri'] = '/api_jasonrpc.php'
+default['zabbix']['web']['api']['scheme']   = 'http'
 default['zabbix']['web']['aliases']         = ['zabbix']
 default['zabbix']['web']['port']            = 80
 

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -140,8 +140,8 @@ action :update do
     if host.nil?
       Chef::Application.fatal! "Could not find host #{new_resource.hostname}"
     end
- 
-    #Get,create and assign groups
+
+    # Get,create and assign groups
     if new_resource.groups.empty?
       group_names = new_resource.parameters[:groupNames]
     else
@@ -170,7 +170,7 @@ action :update do
         # And now fetch the newly made group to be sure it worked
         # and for later use
         group = connection.query(get_desired_groups_request).first
-        Chef::Log.error('Error creating groups, see Chef errors') if result.nil? or group.nil?
+        Chef::Log.error('Error creating groups, see Chef errors') if result.nil? || group.nil?
       elsif group
         Chef::Log.info "Group #{desired_group} already exists"
       else
@@ -178,8 +178,8 @@ action :update do
       end
       acc << group
     end
-    
-    #Get/assign templates
+
+    # Get/assign templates
     if new_resource.templates.empty?
       template_names = new_resource.parameters[:templates]
     else

--- a/recipes/agent_registration.rb
+++ b/recipes/agent_registration.rb
@@ -6,7 +6,7 @@
 #
 
 if !Chef::Config[:solo]
-  zabbix_server = search(:node, 'recipe:zabbix\\:\\:server').first
+  zabbix_server = search(:node, node['zabbix']['agent']['server_search']).first
 else
   if node['zabbix']['web']['fqdn']
     zabbix_server = node
@@ -18,7 +18,7 @@ else
 end
 
 connection_info = {
-  :url => "http://#{zabbix_server['zabbix']['web']['fqdn']}/api_jsonrpc.php",
+  :url => "#{zabbix_server['zabbix']['web']['api']['scheme']}://#{zabbix_server['zabbix']['web']['fqdn']}#{zabbix_server['zabbix']['web']['api']['uri']}",
   :user => zabbix_server['zabbix']['web']['login'],
   :password => zabbix_server['zabbix']['web']['password']
 }


### PR DESCRIPTION
Template filter was wrong, which caused the applied templates to
get removed on the subsuquent chef runs.

Added group creation for existing hosts. Previously, chef would
fail for existing hosts that had non-existing groups added to them

Added a few comments in code.
