### PR TITLE
api call returns template id as templateid not hostid

### DIFF
--- a/providers/application.rb
+++ b/providers/application.rb
@@ -14,7 +14,7 @@ action :create do
         :method => 'application.create',
         :params => {
           :name => new_resource.name,
-          :hostid => template_ids.first['hostid']
+          :hostid => template_ids.first['hostid'] || template_ids.first['templateid']
         }
       }
       connection.query(request)

--- a/providers/item.rb
+++ b/providers/item.rb
@@ -5,7 +5,7 @@ action :create do
       Chef::Application.fatal! "Could not find a template named #{new_resource.template}"
     end
 
-    template_id = template_ids.first['hostid']
+    template_id = template_ids.first['hostid'] || template_ids.first['templateid']
 
     application_ids = new_resource.applications.map do |application|
       app_ids = Zabbix::API.find_application_ids(connection, application, template_id)


### PR DESCRIPTION
running zabbix 2.4.4 with zabbixapi gem 2.4.2, i get converge failures since the api call to template.get returns 'templateid' not 'hostid' . Left the original ref to hostid in since there may be some issues with backwards compatibility with older api calls
