### PR TITLE
Fixed restart failure of zabbix-java-gateway

### DIFF
--- a/files/default/zabbix-java-gateway/init.rhel
+++ b/files/default/zabbix-java-gateway/init.rhel
@@ -112,12 +112,14 @@ case "$1" in
         ;;
     restart)
         $0 stop
+        sleep 1
         $0 start
         RETVAL=$?
         ;;
     condrestart)
         if [ -n "$PID_FILE" -a -e "$PID_FILE" ]; then
             $0 stop
+            sleep 1
             $0 start
         fi
         RETVAL=$?


### PR DESCRIPTION
line 115 in the files/default/zabbix-java-gateway/init.rhel causes a restart error

```
# service zabbix-java-gateway restart
Shutting down zabbix java gateway:                         [  OK  ]
Starting zabbix java gateway: Zabbix java gateway is already running (found com.zabbix.gateway.JavaGateway process).
                                                           [FAILED]
```