### PR TITLE
Add additonal Zabbix server configuration options.

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -19,9 +19,13 @@ default['zabbix']['server']['java_gateway'] = '127.0.0.1'
 default['zabbix']['server']['java_gateway_port'] = 10_052
 default['zabbix']['server']['java_pollers'] = 0
 default['zabbix']['server']['start_pollers'] = 5
+default['zabbix']['server']['start_pingers'] = '1' # default 1
 
 default['zabbix']['server']['externalscriptspath'] = '/usr/local/scripts/zabbix/externalscripts/'
 
 default['zabbix']['server']['timeout'] = '3'
 default['zabbix']['server']['value_cache_size'] = '8M' # default 8MB
 default['zabbix']['server']['cache_size'] = '8M' # default 8MB
+default['zabbix']['server']['history_cache_size'] = '8M' # default 8M
+default['zabbix']['server']['history_text_cache_size'] = '16M' # default 16M
+default['zabbix']['server']['trend_cache_size'] = '4M' # default 4M

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'nacer.laradji@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Zabbix Agent/Server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.8.0'
+version '0.8.1'
 supports 'ubuntu', '>= 10.04'
 supports 'debian', '>= 6.0'
 supports 'redhat', '>= 5.0'

--- a/templates/default/zabbix_server.conf.erb
+++ b/templates/default/zabbix_server.conf.erb
@@ -24,8 +24,13 @@ JavaGateway=<%= @java_gateway %>
 JavaGatewayPort=<%= @java_gateway_port %>
 StartJavaPollers=<%= @java_pollers %>
 StartPollers=<%= node['zabbix']['server']['start_pollers']%>
+StartPingers=<%= node['zabbix']['server']['start_pingers']%>
 
 ExternalScripts=<%= node['zabbix']['server']['externalscriptspath'] %>
 Timeout=<%= node['zabbix']['server']['timeout']%>
 ValueCacheSize=<%= node['zabbix']['server']['value_cache_size'] %>
 CacheSize=<%= node['zabbix']['server']['cache_size'] %>
+HistoryCacheSize=<%= node['zabbix']['server']['history_cache_size'] %>
+HistoryTextCacheSize=<%= node['zabbix']['server']['history_text_cache_size'] %>
+TrendCacheSize=<%= node['zabbix']['server']['trend_cache_size'] %>
+


### PR DESCRIPTION
1) Added extra attributes to the zabbix server configuration.
* start_pingers with default value of 1
* history_cache_size with default value of 8M
* history_text_cache_size with default value of 16M
* trend_cache_size with default value of 4M
2) Updated metadata.rb with minor change to 0.8.1
3) Updated the template to use the values from the zabbix server attributes.