### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Default implementation of how to Fetch and handle the Zabbix source code.
 # CHANGELOG
 
 ### 0.8.0
-* This version is a big change with a lot of bugfix and change. Please be carefull if you are updated from previous version
+* This version is a big change with a lot of bugfix and change. Please be careful if you are updated from previous version
 
 ### 0.0.42
 * Adds Berkshelf/Vagrant 1.1 compatibility (andrewGarson)
@@ -402,7 +402,7 @@ Default implementation of how to Fetch and handle the Zabbix source code.
   * Configuration error about include_dir in zabbix_agentd.conf.erb
 
 ###	0.0.26
-  * zabbix agent and zabbix server don't want the same include_dir, be carefull if you use include_dir
+  * zabbix agent and zabbix server don't want the same include_dir, be careful if you use include_dir
   * noob error on zabbix::server
 
 ### 0.0.25


### PR DESCRIPTION
@laradji, I've corrected a typographical error in the documentation of the [zabbix](https://github.com/laradji/zabbix) project. Specifically, I've changed carefull to careful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
